### PR TITLE
Mute experimental smartmatch warnings

### DIFF
--- a/useradm/bin/pua
+++ b/useradm/bin/pua
@@ -15,6 +15,8 @@ use utf8;
 use Pglistener::Schema;
 use Data::Dumper;
 
+use experimental 'smartmatch';
+
 binmode STDOUT, ":utf8";
 
 my $config = Config::File::read_config_file("/etc/pua.conf");


### PR DESCRIPTION
This is the simplest option to mute these warnings, the best would be to get rid of the experimental features, (~~, given/when).
